### PR TITLE
Change notebook to stack with stack switcher in headerbar

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,9 +23,10 @@ class MainWindow(Gtk.Window):
         hb.props.title = "Get Extensions"
         self.set_titlebar(hb)
 
-        # Create notebook for tabs
-        self.notebook = Gtk.Notebook()
-        self.add(self.notebook)
+        # Create stack
+        self.stack = Gtk.Stack()
+        self.stack.set_transition_type(Gtk.StackTransitionType.SLIDE_LEFT_RIGHT)
+        self.add(self.stack)
 
         # Layout for page1
         self.page1 = Gtk.VBox()
@@ -33,12 +34,12 @@ class MainWindow(Gtk.Window):
         self.searchbox = Gtk.HBox()
         self.page1.pack_start(self.searchbox, True, True, 0)
         self.page1.set_border_width(10)
-        self.notebook.append_page(self.page1, Gtk.Label(label="Download Extensions"))
+        self.stack.add_titled(self.page1, "download", "Download")
 
         # Layout for page2
         self.page2 = Gtk.VBox()
         self.page2.set_border_width(10)
-        self.notebook.append_page(self.page2, Gtk.Label(label="Installed Extensions"))
+        self.stack.add_titled(self.page2, "installed", "Installed")
 
         # Create and attach Entry field to grid
         self.entry = Gtk.Entry()
@@ -73,6 +74,11 @@ class MainWindow(Gtk.Window):
 
         # Populate page2
         self.show_installed_extensions()
+
+        # Create StackSwitcher
+        self.stackswitcher = Gtk.StackSwitcher()
+        self.stackswitcher.set_stack(self.stack)
+        hb.set_custom_title(self.stackswitcher)
 
     def show_installed_extensions(self):
         # Clear old entries


### PR DESCRIPTION
I changed the notebook used to separate pages to a stack, and put a stack switcher in the headerbar.  I think makes the app look a bit more GNOME-ish, and also makes better use of space. (I also added a neat sliding animation)
![stackdemo](https://user-images.githubusercontent.com/32339182/97622647-91925b00-19f2-11eb-9826-6eca3950e3fb.png)
There are a couple issues that come with this that I can work on if you're interested.
1. Now there isn't a title in the headerbar.  This isn't a serious issue, but could make things a bit more confusing.  An About dialog could be nice here, along with eventually properly packaging the app with a .desktop launcher to set a title in the top panel.
2. The window a bit too small and cramped now, imo.  Setting a default window size and/or moving around some elements could help.