### PR TITLE
Use dbus methods

### DIFF
--- a/getextensions/__main__.py
+++ b/getextensions/__main__.py
@@ -139,7 +139,6 @@ class MainWindow(Gtk.Window):
             itembox.set_center_widget(name_label)
 
             # Check if item has prefs before adding the button
-
             if item["prefs"] == True:
                 config_button = Gtk.Button()
                 config_button.set_halign(Gtk.Align.START)
@@ -247,10 +246,10 @@ class MainWindow(Gtk.Window):
 
     def on_switch_activated(self, switch, gparam, name):
         if switch.get_active():
-            self.extmgr.set_extension_status(name, "enable")
+            self.extmgr.enable_extension(name)
             print(name + " enabled")
         else:
-            self.extmgr.set_extension_status(name, "disable")
+            self.extmgr.disable_extension(name)
             print(name + " disabled")
 
     def on_key_press_event(self, widget, event):
@@ -299,7 +298,7 @@ class MainWindow(Gtk.Window):
                 self.removebutton.set_sensitive(False)
 
     def on_config_button_clicked(self, widget, uuid):
-        self.extmgr.run_command("gnome-extensions prefs " + uuid)
+        self.extmgr.launch_extension_prefs(uuid)
 
 if __name__ == "__main__":
     win = MainWindow()


### PR DESCRIPTION
I refactored this to utilize dbus method calls, instead of relying on direct sys calls to gnome-settings and read access to system paths.

It should now be possible for GetExtensions to be packaged as a Flatpak and distributed on Flathub.
I have also prepared and tested a basic manifest file for building a Flatpak.
A single line shell-wrapper for `python3 -m getextensions` is also required, but I'll make a separate PR for this and anything else that comes up.

This should not affect anyone running GetExtensions as a plain python module.